### PR TITLE
#16 - 회원 계정 도메인 구현

### DIFF
--- a/src/main/java/com/my/springboardgradle/domain/UserAccount.java
+++ b/src/main/java/com/my/springboardgradle/domain/UserAccount.java
@@ -1,0 +1,52 @@
+package com.my.springboardgradle.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import javax.persistence.*;
+import java.util.Objects;
+
+@Getter
+@ToString
+@Entity
+public class UserAccount extends AuditingFields{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Setter @Column(nullable = false, length = 50) private String userId;
+    @Setter @Column(nullable = false) private String userPassword;
+
+    @Setter @Column(length = 100) private String email;
+    @Setter @Column(length = 100) private String nickname;
+    @Setter private String memo;
+
+    protected UserAccount() {
+    }
+
+    private UserAccount(String userId, String userPassword, String email, String nickname, String memo) {
+        this.userId = userId;
+        this.userPassword = userPassword;
+        this.email = email;
+        this.nickname = nickname;
+        this.memo = memo;
+    }
+
+    public static UserAccount of(String userId, String userPassword, String email, String nickname, String memo) {
+        return new UserAccount(userId, userPassword, email, nickname, memo);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof UserAccount userAccount)) return false;
+        return Objects.equals(id, userAccount.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/com/my/springboardgradle/repository/UserAccountRepository.java
+++ b/src/main/java/com/my/springboardgradle/repository/UserAccountRepository.java
@@ -1,0 +1,7 @@
+package com.my.springboardgradle.repository;
+
+import com.my.springboardgradle.domain.UserAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserAccountRepository extends JpaRepository<UserAccount, Long> {
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,3 +1,10 @@
+-- 테스트 계정
+-- TODO: 테스트용 계정이지만 비밀번호가 노출된 데이터를 세팅해놔서 개선해야함
+INSERT INTO user_account(user_id, user_password, email, nickname, memo, created_at, created_by, modified_at, modified_by)
+VALUES('LMH', '123qwe!', 'lmh@mail.com', 'NickLMH', 'Memo LMH', now(), 'LMH', now(), 'LMH');
+
+
+-- 임의의 게시글
 insert into Article (title, content, hashtag, created_at, created_by, modified_at, modified_by) values ('Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede.', 'Integer ac leo. Pellentesque ultrices mattis odio. Donec vitae nisi.
 
 Nam ultrices, libero non mattis pulvinar, nulla pede ullamcorper augue, a suscipit nulla elit ac nulla. Sed vel enim sit amet nunc viverra dapibus. Nulla suscipit ligula in lacus.

--- a/src/test/java/com/my/springboardgradle/controller/DataRestTest.java
+++ b/src/test/java/com/my/springboardgradle/controller/DataRestTest.java
@@ -10,12 +10,12 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@Disabled("Spring Data REST 통합테스트는 불필요하므로 제외시킴")
+//@Disabled("Spring Data REST 통합테스트는 불필요하므로 제외시킴")
 @DisplayName("Data REST = API 테스트")
 @Transactional
 @AutoConfigureMockMvc
@@ -90,6 +90,21 @@ public class DataRestTest {
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.valueOf("application/hal+json")))
                 .andDo(print());
+
+    }
+
+    @DisplayName("[api] 회원 관련 API 는 일체 제공하지 않는다.")
+    @Test
+    void giveNothing_whenRequestingUserAccount_thenThrowsException() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/api/userAccounts")).andExpect(status().isNotFound());
+        mvc.perform(post("/api/userAccounts")).andExpect(status().isNotFound());
+        mvc.perform(put("/api/userAccounts")).andExpect(status().isNotFound());
+        mvc.perform(patch("/api/userAccounts")).andExpect(status().isNotFound());
+        mvc.perform(delete("/api/userAccounts")).andExpect(status().isNotFound());
+        mvc.perform(head("/api/userAccounts")).andExpect(status().isNotFound());
 
     }
 }


### PR DESCRIPTION
`UserAccount` 이름으로 회원 계정 도메인 생성
`user`, `account` 등은 mysql 예약어이므로 피함
필드명도 mysql 예약어를 의식하여 정함

테스트 데이터에 임의의 계정 1개 등록
테스트용이지만 패스워드가 노출되는 방식이므로 고민 필요

회원 정보는 API로 노출되지 않았으면 해서
테스트에 404 NOT FOUND 를 확인하는 테스트 추가

This closes #16 