### PR TITLE
#25 - 게시글 페이지네이션 구현

### DIFF
--- a/src/main/java/com/my/springboardgradle/controller/ArticleController.java
+++ b/src/main/java/com/my/springboardgradle/controller/ArticleController.java
@@ -46,6 +46,7 @@ public class ArticleController {
         ArticleWithCommentsResponse article = ArticleWithCommentsResponse.from(articleService.getArticle(articleId));
         map.addAttribute("article", article);
         map.addAttribute("articleComments", article.articleCommentResponses());
+        map.addAttribute("totalCount", articleService.getArticleCount());
         return "articles/detail";
     }
 }

--- a/src/main/java/com/my/springboardgradle/service/ArticleService.java
+++ b/src/main/java/com/my/springboardgradle/service/ArticleService.java
@@ -71,4 +71,8 @@ public class ArticleService {
     public void deleteArticle(long articleId) {
         articleRepository.deleteById(articleId);
     }
+
+    public long getArticleCount() {
+        return articleRepository.count();
+    }
 }

--- a/src/main/resources/templates/articles/detail.html
+++ b/src/main/resources/templates/articles/detail.html
@@ -31,7 +31,7 @@
             </section>
 
             <article id="article-content" class="col-md-7 col-lg-8">
-                <pre>본문<br><br></pre>
+                <pre>본문</pre>
             </article>
         </div>
 
@@ -72,13 +72,17 @@
         </div>
 
         <div class="row g-5">
-            <nav aria-label="Page navigation example">
-                <ul class="pagination justify-content-center">
+            <nav id="pagination" aria-label="Page navigation">
+                <ul class="pagination">
                     <li class="page-item">
-                        <a class="page-link" href="#" aria-label="Previous">이전</a>
+                        <a class="page-link" href="#" aria-label="Previous">
+                            <span aria-hidden="true">&laquo; prev</span>
+                        </a>
                     </li>
                     <li class="page-item">
-                        <a class="page-link" href="#" aria-label="Next">다음</a>
+                        <a class="page-link" href="#" aria-label="Next">
+                            <span aria-hidden="true">next &raquo;</span>
+                        </a>
                     </li>
                 </ul>
             </nav>

--- a/src/main/resources/templates/articles/detail.th.xml
+++ b/src/main/resources/templates/articles/detail.th.xml
@@ -10,13 +10,27 @@
         <attr sel="#created-at" th:datetime="*{createdAt}" th:text="*{#temporals.format(createdAt, 'yyyy-MM-dd HH:mm:ss')}" />
         <attr sel="#hashtag" th:text="*{hashtag}" />
         <attr sel="#article-content/pre" th:text="*{content}" />
-    </attr>
 
-    <attr sel="#article-comments" th:remove="all-but-first">
-        <attr sel="li[0]" th:each="articleComment : ${articleComments}">
-            <attr sel="div/strong" th:text="${articleComment.nickname}" />
-            <attr sel="div/small/time" th:datetime="${articleComment.createdAt}" th:text="${#temporals.format(articleComment.createdAt, 'yyyy-MM-dd HH:mm:ss')}" />
-            <attr sel="div/p" th:text="${articleComment.content}" />
+        <attr sel="#article-comments" th:remove="all-but-first">
+            <attr sel="li[0]" th:each="articleComment : ${articleComments}">
+                <attr sel="div/strong" th:text="${articleComment.nickname}" />
+                <attr sel="div/small/time" th:datetime="${articleComment.createdAt}" th:text="${#temporals.format(articleComment.createdAt, 'yyyy-MM-dd HH:mm:ss')}" />
+                <attr sel="div/p" th:text="${articleComment.content}" />
+            </attr>
+        </attr>
+
+        <attr sel="#pagination">
+            <attr sel="ul">
+                <attr sel="li[0]/a"
+                      th:href="*{id} - 1 <= 0 ? '#' : |/articles/*{id - 1}|"
+                      th:class="'page-link' + (*{id} - 1 <= 0 ? ' disabled' : '')"
+                />
+                <attr sel="li[1]/a"
+                      th:href="*{id} + 1 > ${totalCount} ? '#' : |/articles/*{id + 1}|"
+                      th:class="'page-link' + (*{id} + 1 > ${totalCount} ? ' disabled' : '')"
+                />
+            </attr>
         </attr>
     </attr>
+
 </thlogic>

--- a/src/test/java/com/my/springboardgradle/controller/ArticleControllerTest.java
+++ b/src/test/java/com/my/springboardgradle/controller/ArticleControllerTest.java
@@ -95,12 +95,14 @@ class ArticleControllerTest {
         then(paginationService).should().getPaginationBarNumbers(pageable.getPageNumber(), Page.empty().getTotalPages());
     }
 
-    @DisplayName("[View][Get] 게시글 상세 페이지 - 정상 호출")
+    @DisplayName("[View][Get] 게시글 페이지 - 정상 호출")
     @Test
     public void givenNothing_whenRequestingArticleView_thenReturnArticleView() throws Exception {
         // Given
         Long articleId = 1L;
+        long totalCount = 1L;
         given(articleService.getArticle(articleId)).willReturn(createArticleWithCommentDto());
+        given(articleService.getArticleCount()).willReturn(totalCount);
 
         // When&Then
         mvc.perform(get("/articles/1"))
@@ -111,9 +113,11 @@ class ArticleControllerTest {
                 .andExpect(view().name("articles/detail"))
                 // model 에 해당 키의 데이터가 있는지 확인
                 .andExpect(model().attributeExists("article"))
-                .andExpect(model().attributeExists("articleComments"));
+                .andExpect(model().attributeExists("articleComments"))
+                .andExpect(model().attribute("totalCount", totalCount));
 
         then(articleService).should().getArticle(articleId);
+        then(articleService).should().getArticleCount();
     }
 
     @Disabled("구현 중")

--- a/src/test/java/com/my/springboardgradle/service/ArticleServiceTest.java
+++ b/src/test/java/com/my/springboardgradle/service/ArticleServiceTest.java
@@ -165,6 +165,21 @@ class ArticleServiceTest {
         then(articleRepository).should().deleteById(articleId);
     }
 
+    @DisplayName("게시글 수를 조회하면, 게시글 수를 반환한다")
+    @Test
+    void givenNothing_whenCountingArticles_thenReturnsArticleCount() {
+        // Given
+        long expected = 0L;
+        given(articleRepository.count()).willReturn(expected);
+
+        // When
+        long actual = sut.getArticleCount();
+
+        // Then
+        assertThat(actual).isEqualTo(expected);
+        then(articleRepository).should().count();
+    }
+
     private UserAccount createUserAccount() {
         return UserAccount.of(
                 "lmh",


### PR DESCRIPTION
`이전 글`, `다음 글`만 구현하므로 게시판에 비해 단순하지만
첫 글, 마지막 글은 버튼 비활성화 및 가짜 링크 처리해야 해서
타임리프 문법이 복잡해짐

마지막 글을 판단하기 위해 총 글 개수가 필요해졌고
이를 위해 count 쿼리 사용, 서비스 로직 추가