### PR TITLE
#41 - 해시태그 메뉴를 헤더에 추가

### DIFF
--- a/src/main/resources/templates/header.html
+++ b/src/main/resources/templates/header.html
@@ -13,7 +13,8 @@
             </a>
 
             <ul class="nav col-12 col-lg-auto me-lg-auto mb-2 justify-content-center mb-md-0">
-                <li><a href="#" class="nav-link px-2 text-secondary">Home</a></li>
+                <li><a id="home" href="#" class="nav-link px-2 text-secondary">Home</a></li>
+                <li><a id="hashtag" href="#" class="nav-link px-2 text-secondary">Hashtag</a></li>
             </ul>
             <div class="text-end">
                 <button type="button" class="btn btn-outline-light me-2">Login</button>

--- a/src/main/resources/templates/header.th.xml
+++ b/src/main/resources/templates/header.th.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<thlogic>
+    <attr sel="#home" th:href="@{/}" />
+    <attr sel="#hashtag" th:href="@{/articles/search-hashtag}" />
+</thlogic>


### PR DESCRIPTION
링크는 타임리프 태그로 처리하도록 변경
이러면 스프링 부트로 띄우지 않은 정적 목업 페이지는
링크 동작을 보여주지 않아서 리소스 접근에 안전하다.